### PR TITLE
Fix code scanning alert no. 20: Incomplete string escaping or encoding

### DIFF
--- a/sqli/static/js/materialize.js
+++ b/sqli/static/js/materialize.js
@@ -1328,7 +1328,7 @@ Materialize.guid = function () {
  * @returns {string}
  */
 Materialize.escapeHash = function (hash) {
-  return hash.replace(/(:|\.|\[|\]|,|=)/g, "\\$1");
+  return hash.replace(/\\/g, "\\\\").replace(/(:|\.|\[|\]|,|=)/g, "\\$1");
 };
 
 Materialize.elementOrParentIsFixed = function (element) {


### PR DESCRIPTION
Fixes [https://github.com/Gomes838/dvpwa/security/code-scanning/20](https://github.com/Gomes838/dvpwa/security/code-scanning/20)

To fix the problem, we need to ensure that backslashes are also escaped in the `Materialize.escapeHash` function. This can be done by adding an additional `replace` call to escape backslashes before escaping the other special characters. 

The best way to fix this without changing existing functionality is to first replace all backslashes with double backslashes and then proceed with the existing replacement of other special characters. This ensures that backslashes are properly escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
